### PR TITLE
fix: remove duplicate local track

### DIFF
--- a/src/hooks/use-twilio-video.js
+++ b/src/hooks/use-twilio-video.js
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useReducer, useRef } from 'react';
 import axios from 'axios';
-import { connect, createLocalVideoTrack } from 'twilio-video';
+import { connect } from 'twilio-video';
 
 const TWILIO_TOKEN_URL =
   'https://jasmine-greyhound-8600.twil.io/get-room-token';
@@ -112,9 +112,7 @@ const useTwilioVideo = () => {
       console.error(`Unable to join the room: ${error.message}`);
     });
 
-    const localTrack = await createLocalVideoTrack().catch(error => {
-      console.error(`Unable to create a local video track: ${error.message}`);
-    });
+    const localTrack = [...room.localParticipant.videoTracks.values()][0].track;
 
     // Attach the video to the videoRef
     if (!videoRef.current.hasChildNodes()) {


### PR DESCRIPTION
By default, Twilio's `connect` function will create local video tracks. This update removes the manual creation of local tracks and instead uses the local tracks created by the `connect` function.

See https://github.com/twilio/video-quickstart-js/issues/48#issuecomment-531412443 for details.

fixes #1 